### PR TITLE
Fix draws being erroneously classified as wins

### DIFF
--- a/src/chess_zero/env/chess_env.py
+++ b/src/chess_zero/env/chess_env.py
@@ -7,7 +7,7 @@ from logging import getLogger
 logger = getLogger(__name__)
 
 # noinspection PyArgumentList
-Winner = enum.Enum("Winner", "black white draw")
+Winner = enum.Enum("Winner", "black white draw undetermined")
 
 
 class ChessEnv:
@@ -47,7 +47,7 @@ class ChessEnv:
 
         self.turn += 1
 
-        if self.board.is_game_over() or self.board.can_claim_threefold_repetition():
+        if self.board.is_game_over(claim_draw=True):
             self._game_over()
 
         return self.board, {}
@@ -55,19 +55,11 @@ class ChessEnv:
     def _game_over(self):
         self.done = True
         if self.winner is None:
-            result = self.board.result()
-            if result == '1-0':
-                self.winner = Winner.white
-            elif result == '0-1':
-                self.winner = Winner.black
-            else:
-                val_black, val_white = self.score_board()
-                if val_black > val_white:
-                    self.winner = Winner.black
-                elif val_black < val_white:
-                    self.winner = Winner.white
-                else:
-                    self.winner = Winner.draw
+            result = self.board.result(claim_draw=True)
+            self.winner = Winner.white if result == '1-0' \
+                else Winner.black if result == '0-1' \
+                else Winner.draw if result == '1/2-1/2' \
+                else Winner.undetermined
 
     def score_current(self):
         val_black, val_white = self.score_board()

--- a/src/chess_zero/worker/self_play.py
+++ b/src/chess_zero/worker/self_play.py
@@ -64,7 +64,8 @@ class SelfPlayWorker:
             board, info = self.env.step(action)
             observation = board.fen()
         self.finish_game()
-        self.save_play_data(write=idx % self.config.play_data.nb_game_in_file == 0)
+        if self.env.winner != Winner.undetermined:
+            self.save_play_data(write=idx % self.config.play_data.nb_game_in_file == 0)
         self.remove_play_data()
         return self.env
 
@@ -90,6 +91,9 @@ class SelfPlayWorker:
             os.remove(files[i])
 
     def finish_game(self):
+        if self.env.winner == Winner.undetermined:
+            return
+
         if self.env.winner == Winner.black:
             black_win = 1
         elif self.env.winner == Winner.white:


### PR DESCRIPTION
While running self-play I stumbled upon the following game result:
```
2017-12-10 16:59:02,316@chess_zero.worker.self_play DEBUG # game 98 time=294.752
04849243164 sec, turn=171:6K1/k7/b7/8/8/8/8/8 w - - 0 172 - Winner:Winner.black 
- by resignation?:False
```

This is a theoretical draw, but is classified as a win for black. The current self-play code also doesn't account for stalemates nor for the fifty-move rule, and erroneously adjudicates the game's outcome based on a material count.

This PR fixes this by classifying a game's outcome as a draw if one may be claimed.