### PR TITLE
Update requirements.txt. Add version keras

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-chess==0.25.1
 tensorflow-gpu==1.15.2
-keras
+keras==2.0.8
 profilehooks
 numpy
 pyperclip


### PR DESCRIPTION
Keras currently upgrated to version 2.3.1 and it made new issues : 
```cmd
tensorflow.python.framework.errors_impl.InvalidArgumentError: Tensor input_1:0, specified in either feed_devices or fetch_devices was not found in the Graph
```
Solution: Downgrade Keras version